### PR TITLE
Lagabreytingartillaga

### DIFF
--- a/segull_log.md
+++ b/segull_log.md
@@ -38,7 +38,7 @@
             3. Kosning þriggja manna í uppstillingrnefnd til eins árs.
         8. Önnur mál
 5. **Stjórn félagsins**  
-    1. Stjórn félagsins skal skipuð sjö einstaklingum. Félagsforingja og 6 meðstjórnendum.
+    1. Stjórn félagsins skal skipuð fimm einstaklingum. Félagsforingja og 4 meðstjórnendum.
     2. Stjórnarmenn skulu kosnir til tveggja ára í senn.
     3. Stjórnin kýs úr hópi meðstjórnanda aðstoðarfélagsforingja og gjaldkera.
     4. Láti stjórnarmaður af störfum á tímabilinu skal foringjaráð kjósa nýjan í hans stað fram að næsta aðalfundi.
@@ -70,4 +70,4 @@
     7. Foringjaráð skal setja vinnureglur fyrir sveitaforingja.
     8. Einfaldur meirihluti nægir við atkvæðagreiðslur nema þegar lögum er breytt, félagið lagt niður eða húsnæði félagsins selt, þá þarf 2/3 hluta atkvæða
     9. Lög og reglur félagsins skulu vera aðgengilegar í skátaheimilinu og æskilegt er að þær séu aðgengilegar á vef félagsins.
-    10. Lög þessi eru sett á aðalfundi Skátafélagsins Seguls 26. nóvember 2006 og breytt á aðalfundi 18. febrúar 2016 og öðlast þegar gildi.
+    10. Lög þessi eru sett á aðalfundi Skátafélagsins Seguls 26. nóvember 2006 og breytt á aðalfundi 21. febrúar 2018 og öðlast þegar gildi.


### PR DESCRIPTION
Stjórn Seguls hefur nú starfað undanfarin ár með sjö stjórnarmeðlimi.  Reynslan hefur sýnt að með minnkandi umsvifum félagsins er þörfin fyrir svo marga stjórnarmeðlimi lítil, virkni hvers og eins minni og erfiðara að manna lausar stöður.  Auk þess lítum við til hugmynda BÍS um svokallaða “finnska leið” í stjórnun félaga þar sem hlutverk hvers og eins er afmarkað og skilgreint í smáatriðum og leggjum til að fyrsta skrefið í áttina að þeirri leið sé að fækka stjórnarmeðlimum úr sjö í fimm.

Þar er gert ráð fyrir þremur stjórnarmeðlimum sem skipta með sér þremur ábyrgðarþáttum: félaginu, dagskránni og mannauðnum. Hver og einn ber þá ábyrgð á einum þessara þriggja þátta og mun njóta til þess stuðnings beint frá BÍS auk annarra stjórnarmeðlima.  Við teljum að þetta gæti verið góð lausn fyrir félagið og að stefna beri á að taka hana upp í nánustu framtíð.